### PR TITLE
fix parser if vlan config is on multiple lines

### DIFF
--- a/plugins/module_utils/network/os6.py
+++ b/plugins/module_utils/network/os6.py
@@ -195,6 +195,10 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'(tacacs-server) host.*$')]
 
     childline = re.compile(r'^exit\s*$')
+
+    # bring vlan config to one single line
+    lines = re.sub("(?<=vlan )([0-9,-]+)\nvlan ", "\\1,", lines, 0, re.MULTILINE)
+
     config = list()
     parent = list()
     children = []


### PR DESCRIPTION
DellOS6 wrap vlan config if lots of vlans are configured. Fix parser to set whole config in one single line.